### PR TITLE
Package.json "Simplifications"

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "main": "js/app.js",
   "scripts": {
     "watch-css": "nodemon -I -w less/ --ext less --exec 'npm run build-css'",
-    "watch-js": "watchify js/app.js -o 'browserify js/app.js > static/bundle.js' -v",
+    "watch-js": "watchify js/app.js -o static/bundle.js -v",
     "watch": "npm run watch-css & npm run watch-js",
     "postprocess-css": "autoprefixer static/bundle.css",
     "build-css": "lessc less/core.less static/bundle.css && npm run postprocess-css; true",
-    "build-js": "browserify js/app.js > static/bundle.js",
+    "build-js": "browserify js/app.js -o static/bundle.js",
     "build": "npm run build-css & npm run build-js",
     "jshint": "jshint --reporter node_modules/jshint-stylish/stylish.js js/; true",
     "test": "npm run jshint && mocha test"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "babelify": "^6.0.2",
     "browserify": "^10.1.3",
     "jshint": "^2.7.0",
+    "jshint-stylish": "^1.0.2",
     "mocha": "^2.2.4",
     "nodemon": "^1.3.7",
     "uglifyify": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "main": "js/app.js",
   "scripts": {
     "watch-css": "nodemon -I -w less/ --ext less --exec 'npm run build-css'",
-    "watch-js": "watchify js/app.js -o 'browserify js/app.js -t babelify -t uglifyify > static/bundle.js' -v",
+    "watch-js": "watchify js/app.js -o 'browserify js/app.js > static/bundle.js' -v",
     "watch": "npm run watch-css & npm run watch-js",
     "postprocess-css": "autoprefixer static/bundle.css",
     "build-css": "lessc less/core.less static/bundle.css && npm run postprocess-css; true",
-    "build-js": "browserify js/app.js -t babelify -t uglifyify > static/bundle.js",
+    "build-js": "browserify js/app.js > static/bundle.js",
     "build": "npm run build-css & npm run build-js",
     "jshint": "jshint --reporter node_modules/jshint-stylish/stylish.js js/; true",
     "test": "npm run jshint && mocha test"
@@ -25,6 +25,12 @@
       "url": "http://tmn.mit-license.org"
     }
   ],
+  "browserify": {
+    "transform": [
+      "babelify",
+      "uglifyify"
+    ]
+  },
   "devDependencies": {
     "autoprefixer": "^5.1.1",
     "babelify": "^6.0.2",


### PR DESCRIPTION
Hi!

Some suggestions, if you want:
- Moves transforms to separate package property (easier to extend)
- Removes unnecessary command duplication for watchify (or was it there for a reason?)
- Adds missing dev dep: jshint-stylish.

Should also consider adding a `.jshintrc` as babelify is installed (setting jshint option esnext).
